### PR TITLE
return donation summary for user + bug fix

### DIFF
--- a/app/Modules/User/Resources/UserResource.php
+++ b/app/Modules/User/Resources/UserResource.php
@@ -24,6 +24,8 @@ class UserResource extends JsonResource
             "address" => $this->address,
             "img" => $this->img ? asset('storage/users/images/'.$this->img) : null,
             "active" => $this->active,
+            'total_donation_spent' => $this->donations()->sum('amount'),
+            'donation_count' => $this->donations()->count(),
             "created_at" => $this->created_at,
             "updated_at" => $this->updated_at,
         ];

--- a/database/migrations/2024_05_26_081136_create_firebase_device_tokens_table.php
+++ b/database/migrations/2024_05_26_081136_create_firebase_device_tokens_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('firebase_device_tokens', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->nullable()->constrained();
-            $table->text('token')->unique();
+            $table->string('token',255)->unique();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
1. fixed `token` data type  in  `database/migrations/2024_05_26_081136_create_firebase_device_tokens_table.php`  that should be a string with specified length 
2. added to the `UserResource` in the `public function getAuthUser()` 2 values needed :
  - `total_donation_spent` : to know the total amount of donation paid
  -  `donation_count` :  how many  operations are done by that user 